### PR TITLE
set fromCache attribute if images were in the browser cache.

### DIFF
--- a/load_image.js
+++ b/load_image.js
@@ -30,6 +30,7 @@
     // call the callback by hand.
     //
     if (img[0].complete || img[0].readyState) {
+      img.attr('fromCache', 'true');
       successCallback();
     }
 


### PR DESCRIPTION
Useful in to.be for knowing whether an image was cached or downloaded
before logging download speed metrics.
